### PR TITLE
Don't fail when unable to loadClass

### DIFF
--- a/src/main/java/eu/somatik/maven/serviceloader/ServiceloaderMojo.java
+++ b/src/main/java/eu/somatik/maven/serviceloader/ServiceloaderMojo.java
@@ -200,8 +200,9 @@ public class ServiceloaderMojo extends AbstractMojo {
 					}
 				}
 			} catch (ClassNotFoundException e1) {
-				getLog().error(e1);
-				throw new MojoExecutionException("Could not load class: " + className, e1);
+				getLog().warn(e1);
+			} catch (NoClassDefFoundError e2) {
+				getLog().warn(e2);
 			}
 		}
 		return serviceImplementations;


### PR DESCRIPTION
If a project class extends a class from a system library the plugin throws an exception causing the build process to fail. Hopefully this is a reasonable solution to this.
