### PR TITLE
Add a filter for including or excluding implementation classes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,42 @@ this will generate these files:
 
 by scanning the generated classes and finding all non-abstract/non-interface implementations of the service interfaces. The plugin itself has no Java 6 dependency
 
+Additionally it is possible to filter implementation classes via includes and excludes section in the configuration. The class name notation is the same as for the services section.
+
+for example:
+```xml
+<build>
+  <plugins>
+    <plugin>
+      <groupId>eu.somatik.serviceloader-maven-plugin</groupId>
+      <artifactId>serviceloader-maven-plugin</artifactId>
+      <version>1.0.6</version>
+      <configuration>
+        <services>
+          <param>com.foo.Dictionary</param>
+          <param>com.foo.Operation</param>
+        </services>
+        <includes>
+          <include>*.RightClass*</include>
+        </includes>
+      </configuration>
+      <executions>
+        <execution>
+          <goals>
+            <goal>generate</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+  </plugins>
+</build>
+```
+
+This should add only implementation classes that begin with RightClass*.
+
 A example project is provided and can be run like this:
 
-    $ mvn2 clean install
+    $ mvn clean install
     ...
     [INFO] Generating service file .../example/target/classes/META-INF/services/eu.somatik.serviceloader.Operation
     [INFO]   + eu.somatik.serviceloader.SimpleOperation

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 Francis De Brabandere <info@somatik.eu>
+    Copyright (C) 2016 Francis De Brabandere <info@somatik.eu>
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
I've implemented a filter for including / excluding implementation classes and updated the readme with some sample code.

It is now possible to use the elements <includes><include>*.SomeClass*</include></includes> and /or <excludes><exclude>*.SomeClass*</exclude></excludes> in the configuration section. 

Tests are missing at the moment.