### PR TITLE
Fix bug when using multiple excludes

### DIFF
--- a/src/main/java/eu/somatik/maven/serviceloader/ServiceloaderMojo.java
+++ b/src/main/java/eu/somatik/maven/serviceloader/ServiceloaderMojo.java
@@ -253,10 +253,12 @@ public class ServiceloaderMojo extends AbstractMojo {
                 
                 while ( classNamesIter.hasNext())
                 {
+                    String className = classNamesIter.next();
                     for ( String exclude : excludes )
                     {
-                        if(SelectorUtils.match(exclude, classNamesIter.next())) {
+                        if(SelectorUtils.match(exclude, className)) {
                           classNamesIter.remove();
+                          break;
                         }
                     }
                 }


### PR DESCRIPTION
When using multiple excludes, current implementation will continue iterating the classes while checking the excludes pattern.
This is a major bug if one uses more than one exclude.

The fix simply iterates once and check all exclusions before checking next class.