### PR TITLE
Add option to skip missing services

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,37 @@ for example:
 
 This should add only implementation classes that begin with RightClass*.
 
+# Missing Service Classes
+
+The default action when a service class is missing is to fail the build.
+If you want to ignore this service, you can use the `failOnMissingServiceClass` option (`true` by default).
+
+for example:
+```xml
+<build>
+  <plugins>
+    <plugin>
+      <groupId>eu.somatik.serviceloader-maven-plugin</groupId>
+      <artifactId>serviceloader-maven-plugin</artifactId>
+      <version>1.1.0</version>
+      <configuration>
+      	<failOnMissingServiceClass>false</failOnMissingServiceClass>
+        <services>
+          <param>com.foo.MissingService</param>
+        </services>
+      </configuration>
+      <executions>
+        <execution>
+          <goals>
+            <goal>generate</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+  </plugins>
+</build>
+```
+
 # Example
 
 A example project is provided and can be run like this:

--- a/src/main/java/eu/somatik/maven/serviceloader/ServiceloaderMojo.java
+++ b/src/main/java/eu/somatik/maven/serviceloader/ServiceloaderMojo.java
@@ -88,6 +88,9 @@ public class ServiceloaderMojo extends AbstractMojo {
     
     @Parameter
     private String[] excludes;
+    
+    @Parameter(defaultValue ="true")
+    private boolean failOnMissingServiceClass;
 
     public MavenProject getProject() {
         return project;
@@ -183,7 +186,11 @@ public class ServiceloaderMojo extends AbstractMojo {
                 Class<?> serviceClass = loader.loadClass(serviceClassName);
                 serviceClasses.add(serviceClass);
             } catch (ClassNotFoundException ex) {
-                throw new MojoExecutionException("Could not load class: " + serviceClassName, ex);
+                if (failOnMissingServiceClass) {
+                    throw new MojoExecutionException("Could not load class: " + serviceClassName, ex);
+                } else {
+                    getLog().info("Skipping missing service class: " + serviceClassName);
+                }
             }
         }
         return serviceClasses;
@@ -200,8 +207,8 @@ public class ServiceloaderMojo extends AbstractMojo {
     private Map<String, List<String>> findImplementations(ClassLoader loader,
                                                           List<Class<?>> interfaceClasses) throws MojoExecutionException {
         Map<String, List<String>> serviceImplementations = new HashMap<String, List<String>>();
-        for (String interfaceClassName : getServices()) {
-            serviceImplementations.put(interfaceClassName, new ArrayList<String>());
+        for (Class<?> interfaceClass: interfaceClasses) {
+            serviceImplementations.put(interfaceClass.getName(), new ArrayList<String>());
         }
         getLog().info("Scanning generated classes for implementations...");
         File classFolder = getClassFolder();

--- a/src/test/java/eu/somatik/maven/serviceloader/ServiceloaderMojoTest.java
+++ b/src/test/java/eu/somatik/maven/serviceloader/ServiceloaderMojoTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class ServiceloaderMojoTest {
@@ -124,5 +125,32 @@ public class ServiceloaderMojoTest {
         String serviceFileContents = FileUtils.fileRead(serviceFile);
         Set<String> classNames = Sets.newHashSet(serviceFileContents.trim().split("\n"));
         assertEquals(Sets.newHashSet("com.baz.BazExt", "com.baz.BazExt2"), classNames);
+    }
+
+    @Test
+    public void testNotFailOnMissingClass() throws MojoExecutionException, IllegalAccessException, IOException {
+        BuildContext buildContext = new DefaultBuildContext();
+        ServiceloaderMojo mojo = new ServiceloaderMojo();
+        mojo.setBuildContext(buildContext);
+        ReflectionUtils.setVariableValueInObject(mojo, "services", new String[] { "com.baz.MissingService" });
+        ReflectionUtils.setVariableValueInObject(mojo, "compileClasspath", Collections.<String>emptyList());
+        ReflectionUtils.setVariableValueInObject(mojo, "classFolder", new File("target/test-classes"));
+        ReflectionUtils.setVariableValueInObject(mojo, "failOnMissingServiceClass", false);
+        mojo.execute();
+
+        File serviceFile = new File("target/test-classes/META-INF/services/com.baz.MissingService");
+        assertFalse(serviceFile.exists());
+    }
+
+    @Test(expected = MojoExecutionException.class)
+    public void testFailOnMissingClass() throws MojoExecutionException, IllegalAccessException, IOException {
+        BuildContext buildContext = new DefaultBuildContext();
+        ServiceloaderMojo mojo = new ServiceloaderMojo();
+        mojo.setBuildContext(buildContext);
+        ReflectionUtils.setVariableValueInObject(mojo, "services", new String[] { "com.baz.MissingService" });
+        ReflectionUtils.setVariableValueInObject(mojo, "compileClasspath", Collections.<String>emptyList());
+        ReflectionUtils.setVariableValueInObject(mojo, "classFolder", new File("target/test-classes"));
+        ReflectionUtils.setVariableValueInObject(mojo, "failOnMissingServiceClass", true);
+        mojo.execute();
     }
 }


### PR DESCRIPTION
This PR adds a new option to not fail the build when the service class is missing, also adds unit tests and documentation for the new feature.